### PR TITLE
Add fulltext metadata information

### DIFF
--- a/templates/article/header.tpl
+++ b/templates/article/header.tpl
@@ -23,6 +23,15 @@
 
 	{include file="article/dublincore.tpl"}
 	{include file="article/googlescholar.tpl"}
+
+	{foreach from=$article->getGalleys() item=cc_galley}
+		{if $cc_galley->getFileType()=="application/pdf"}
+			<meta name="fulltext_pdf" content="{url page="article" op="download" path=$article->getBestArticleId($currentJournal)|to_array:$cc_galley->getBestGalleyId($currentJournal)}"/>	
+		{else}
+			<meta name="fulltext_html" content="{url page="article" op="view" path=$article->getBestArticleId($currentJournal)|to_array::$cc_galley->getBestGalleyId($currentJournal)}"/>
+		{/if>
+	{/foreach}
+
 	{call_hook name="Templates::Article::Header::Metadata"}
 
 	<link rel="stylesheet" href="{$baseUrl}/lib/pkp/styles/pkp.css" type="text/css" />


### PR DESCRIPTION
Adding metadata to each article about its fulltext path will allow services like CrossCheck to get access to full text of articles.
